### PR TITLE
fix logout async

### DIFF
--- a/REST/PhotoFrame/app.js
+++ b/REST/PhotoFrame/app.js
@@ -198,12 +198,14 @@ app.get('/', (req, res) => {
   }
 });
 
-// GET request to log out the user.
+// POST request to log out the user.
 // Destroy the current session and redirect back to the log in screen.
-app.get('/logout', (req, res) => {
-  req.logout();
-  req.session.destroy();
-  res.redirect('/');
+app.post('/logout', function(req, res, next) {
+  req.logout(function(err) {
+    if (err) { return next(err); }
+    res.redirect('/');
+    req.session.destroy();
+  });
 });
 
 // Star the OAuth login process for Google.


### PR DESCRIPTION
Since version 0.6.0 (which was released only a few days ago by the time of writing this), req.logout is asynchronous. This is part of a larger change that averts session fixation attacks.

See the [release announcement](https://medium.com/passportjs/fixing-session-fixation-b2b68619c51d):

The other major change is that that req.logout() is now an asynchronous function, whereas previously it was synchronous. For instance, a logout route that was previously:

app.post('/logout', function(req, res, next) {
  req.logout();
  res.redirect('/');
});
should be modified to:

app.post('/logout', function(req, res, next) {
  req.logout(function(err) {
    if (err) { return next(err); }
    res.redirect('/');
  });
});